### PR TITLE
add MSP motor telemetry support

### DIFF
--- a/unavlib/__init__.py
+++ b/unavlib/__init__.py
@@ -1531,6 +1531,16 @@ class MSPy:
     def process_MSP_SET_BLACKBOX_CONFIG(self, data):
         logging.info("Blackbox config saved")
 
+    def process_MSP_MOTOR_TELEMETRY(self, data):
+        motorCount = self.readbytes(data, size=8, unsigned=True)
+        for i in range(motorCount):
+            self.MOTOR_TELEMETRY_DATA['rpm'][i] = self.readbytes(data, size=32, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['invalidPercent'][i] = self.readbytes(data, size=16, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['temperature'][i] = self.readbytes(data, size=8, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['voltage'][i] = self.readbytes(data, size=16, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['current'][i] = self.readbytes(data, size=16, unsigned=True)
+            self.MOTOR_TELEMETRY_DATA['consumption'][i] = self.readbytes(data, size=16, unsigned=True)
+
     # TODO: This changed and it will need to check the BF version to decode things correctly
     # def process_MSP_TRANSPONDER_CONFIG(self, data):
     #     bytesRemaining = len(data)

--- a/unavlib/msp_vars.py
+++ b/unavlib/msp_vars.py
@@ -47,6 +47,15 @@ SENSOR_DATA = {
 
 MOTOR_DATA = [0]*8
 
+MOTOR_TELEMETRY_DATA = {
+    'rpm': [0]*8,
+    'invalidPercent': [0]*8,
+    'temperature': [0]*8,
+    'voltage': [0]*8,
+    'current': [0]*8,
+    'consumption': [0]*8,
+}
+
 # defaults
 # roll, pitch, yaw, throttle, aux 1, ... aux n
 RC = {


### PR DESCRIPTION
This still has the same issue with the telemetry data being out of date until receiving it a handful of times, as described [here](https://github.com/thecognifly/YAMSPy/pull/27). Other than that, the telemetry works.